### PR TITLE
Updates to try to fix the protected branch publishing workflow

### DIFF
--- a/.github/workflows/release-all-os.yml
+++ b/.github/workflows/release-all-os.yml
@@ -34,15 +34,20 @@ jobs:
           args: release --snapshot --rm-dist
       - name: set up Git
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR_NAME: "robot-mac-fc"
+          GITHUB_ACTOR_EMAIL: "mac-fc-infra@truss.works"
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-      - name: commit and push changes
+          git config user.name "${GITHUB_ACTOR_NAME}"
+          git config user.email "${GITHUB_ACTOR_EMAIL}"
+      - name: commit changes
         run: |
           git add .
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -m 'Publish release'
-            git push
           fi
+      - name: Push to protected branch
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.ROBOT_MAC_FC_TOKEN }}
+          branch: ${{ github.ref }}
+          unprotect_reviews: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,9 @@
 name: validate
 on:
   pull_request:
+  push:
+    branches:
+      - 'push-action/**'
 
 
 jobs:


### PR DESCRIPTION
We've created a new token on robot-mac-fc user (initially created for Atlantis) so that we can publish to protected branches in a GitHub Actions workflow. Hopefully, this fixes issues publishing changes after merge to main from PRs.